### PR TITLE
Add hourAngle function and wrapper function w/ equatorial coordinates

### DIFF
--- a/src/SolarCalculator.cpp
+++ b/src/SolarCalculator.cpp
@@ -117,13 +117,14 @@ void equatorial2horizontal(double H, double dec, double lat, double &az, double 
     el = degrees(asin(sin(radians(lat)) * sin(radians(dec)) + cos(radians(lat)) * cos(radians(dec)) * cos(radians(H))));
 }
 
-double calcHourAngle(JulianDay jd, double longitude)
+double calcHourAngle(JulianDay jd, double longitude, double rt_ascension)
 {
-    double T = calcJulianCent(jd);
-    double GMST = calcGrMeanSiderealTime(jd);
-    double ra, dec;
-    calcSolarCoordinates(T, ra, dec);
-    double H = wrapTo180(GMST + longitude - ra);
+    double LST = calcGrMeanSiderealTime(jd) + longitude;
+    double H = LST - rt_ascension;
+
+    // Ensure the hour angle is within [0, 360)
+    H = wrapTo360(H);
+
     return H;
 }
 
@@ -247,6 +248,20 @@ void calcEquatorialCoordinates(int year, int month, int day, int hour, int minut
 {
     JulianDay jd(year, month, day, hour, minute, second);
     calcEquatorialCoordinates(jd, rt_ascension, declination, radius_vector);
+}
+
+void calcEquatorialAndHourAngle(unsigned long utc, double longitude, double &rt_ascension, double &declination, double &radius_vector, double &hour_angle)
+{
+    JulianDay jd(utc);
+    calcEquatorialCoordinates(jd, rt_ascension, declination, radius_vector);
+    hour_angle = calcHourAngle(jd, longitude, rt_ascension);
+}
+
+void calcEquatorialAndHourAngle(int year, int month, int day, int hour, int minute, int second, double longitude, double &rt_ascension, double &declination, double &radius_vector, double &hour_angle)
+{
+    JulianDay jd(year, month, day, hour, minute, second);
+    calcEquatorialCoordinates(jd, rt_ascension, declination, radius_vector);
+    hour_angle = calcHourAngle(jd, longitude, rt_ascension);
 }
 
 void calcHorizontalCoordinates(unsigned long utc, double latitude, double longitude,

--- a/src/SolarCalculator.cpp
+++ b/src/SolarCalculator.cpp
@@ -117,6 +117,16 @@ void equatorial2horizontal(double H, double dec, double lat, double &az, double 
     el = degrees(asin(sin(radians(lat)) * sin(radians(dec)) + cos(radians(lat)) * cos(radians(dec)) * cos(radians(H))));
 }
 
+double calcHourAngle(JulianDay jd, double longitude)
+{
+    double T = calcJulianCent(jd);
+    double GMST = calcGrMeanSiderealTime(jd);
+    double ra, dec;
+    calcSolarCoordinates(T, ra, dec);
+    double H = wrapTo180(GMST + longitude - ra);
+    return H;
+}
+
 // Hour angle at sunrise or sunset, returns NaN if circumpolar
 double calcHourAngleRiseSet(double dec, double lat, double h0)
 {

--- a/src/SolarCalculator.h
+++ b/src/SolarCalculator.h
@@ -52,6 +52,7 @@ double calcGrMeanSiderealTime(JulianDay jd);
 
 // Sun's position in the sky
 void equatorial2horizontal(double H, double dec, double lat, double &az, double &el);
+double calcHourAngle(JulianDay jd, double longitude);
 double calcHourAngleRiseSet(double dec, double lat, double h0);
 double calcRefraction(double el);
 

--- a/src/SolarCalculator.h
+++ b/src/SolarCalculator.h
@@ -52,7 +52,7 @@ double calcGrMeanSiderealTime(JulianDay jd);
 
 // Sun's position in the sky
 void equatorial2horizontal(double H, double dec, double lat, double &az, double &el);
-double calcHourAngle(JulianDay jd, double longitude);
+double calcHourAngle(JulianDay jd, double longitude, double rt_ascension);
 double calcHourAngleRiseSet(double dec, double lat, double h0);
 double calcRefraction(double el);
 
@@ -88,6 +88,10 @@ void calcEquationOfTime(int year, int month, int day, int hour, int minute, int 
 void calcEquatorialCoordinates(unsigned long utc, double &rt_ascension, double &declination, double &radius_vector);
 void calcEquatorialCoordinates(int year, int month, int day, int hour, int minute, int second,
                                double &rt_ascension, double &declination, double &radius_vector);
+
+void calcEquatorialAndHourAngle(unsigned long utc, double longitude, double &rt_ascension, double &declination, double &radius_vector, double &hour_angle);
+void calcEquatorialAndHourAngle(int year, int month, int day, int hour, int minute, int second, double longitude,
+                                double &rt_ascension, double &declination, double &radius_vector, double &hour_angle);
 
 void calcHorizontalCoordinates(unsigned long utc, double latitude, double longitude,
                                double &azimuth, double &elevation);


### PR DESCRIPTION
For telescopes and other things that rely on equatorial mounts, it is necessary to calculate hour angle in addition to declination. I added one new function and two wrapper functions that calculate equatorial coordinates and hour angle (one w/ unix time one with time a variables, like the existing equatorial coordinates function).